### PR TITLE
Add OPENSSL_HAS_QUIC define

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2488,6 +2488,14 @@ __owur int SSL_get_peer_quic_transport_version(const SSL *ssl);
 
 int SSL_CIPHER_get_prf_nid(const SSL_CIPHER *c);
 
+/*
+ * This define is really the inverse of the OPENSSL_NO_QUIC define. It
+ * allows easier detection of whether the QUIC APIs are available in
+ * a particular OpenSSL instance when the default assumption is that
+ * they are.
+ */
+#define OPENSSL_HAS_QUIC
+
 #  endif
 
 # ifdef  __cplusplus


### PR DESCRIPTION
Inverse of the OPENSSL_NO_QUIC, the OPENSSL_HAS_QUIC is only defined when QUIC is available.

This would also need to be applied to the 3.0.0 branch.

I have (as of today) signed and submitted the OpenSSL CLA.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
