### PR TITLE
QUIC: Add compile/run-time checking for QUIC

### DIFF
--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -39,6 +39,10 @@ const char *OpenSSL_version(int t)
 #else
         return "ENGINESDIR: N/A";
 #endif
+#ifndef OPENSSL_NO_QUIC
+    case OPENSSL_INFO_QUIC:
+	return "QUIC";
+#endif
     }
     return "not available";
 }

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -161,6 +161,10 @@ const char *OpenSSL_version(int type);
 # define OPENSSL_DIR              4
 # define OPENSSL_ENGINES_DIR      5
 
+# ifndef OPENSSL_NO_QUIC
+#  define OPENSSL_INFO_QUIC       2000
+# endif
+
 int OPENSSL_issetugid(void);
 
 typedef void CRYPTO_EX_new (void *parent, void *ptr, CRYPTO_EX_DATA *ad,


### PR DESCRIPTION
Different from 3.0.0 as there's no OpenSSL_info()

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
