### PR TITLE
QUIC: Make SSL_provide_quic_data accept 0 length data

### DIFF
--- a/ssl/ssl_quic.c
+++ b/ssl/ssl_quic.c
@@ -143,6 +143,9 @@ int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
         return 0;
     }
 
+    if (len == 0)
+        return 1;
+
     if (ssl->quic_buf == NULL) {
         BUF_MEM *buf;
         if ((buf = BUF_MEM_new()) == NULL) {


### PR DESCRIPTION
This commit makes SSL_provide_quic_data accept 0 length data, which
matches BoringSSL behavior.

Fixes #9

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
