### PR TITLE
QUIC: Fix CI

### DIFF
--- a/Configure
+++ b/Configure
@@ -557,6 +557,7 @@ my @disable_cascades = (
                              "sm3", "sm4", "srp",
                              "srtp", "ssl3-method",
                              "ts", "ui-console", "whirlpool",
+                             "quic",
                              "fips-securitychecks" ],
     sub { $config{processor} eq "386" }
                         => [ "sse2" ],
@@ -564,7 +565,7 @@ my @disable_cascades = (
     "ssl3-method"       => [ "ssl3" ],
     "zlib"              => [ "zlib-dynamic" ],
     "des"               => [ "mdc2" ],
-    "ec"                => [ "ec2m", "ecdsa", "ecdh", "sm2", "gost" ],
+    "ec"                => [ "ec2m", "ecdsa", "ecdh", "sm2", "gost", "quic" ],
     "dgram"             => [ "dtls", "sctp" ],
     "sock"              => [ "dgram" ],
     "dtls"              => [ @dtls ],

--- a/doc/build.info
+++ b/doc/build.info
@@ -2150,6 +2150,10 @@ DEPEND[html/man3/SSL_CTX_set_psk_client_callback.html]=man3/SSL_CTX_set_psk_clie
 GENERATE[html/man3/SSL_CTX_set_psk_client_callback.html]=man3/SSL_CTX_set_psk_client_callback.pod
 DEPEND[man/man3/SSL_CTX_set_psk_client_callback.3]=man3/SSL_CTX_set_psk_client_callback.pod
 GENERATE[man/man3/SSL_CTX_set_psk_client_callback.3]=man3/SSL_CTX_set_psk_client_callback.pod
+DEPEND[html/man3/SSL_CTX_set_quic_method.html]=man3/SSL_CTX_set_quic_method.pod
+GENERATE[html/man3/SSL_CTX_set_quic_method.html]=man3/SSL_CTX_set_quic_method.pod
+DEPEND[man/man3/SSL_CTX_set_quic_method.3]=man3/SSL_CTX_set_quic_method.pod
+GENERATE[man/man3/SSL_CTX_set_quic_method.3]=man3/SSL_CTX_set_quic_method.pod
 DEPEND[html/man3/SSL_CTX_set_quiet_shutdown.html]=man3/SSL_CTX_set_quiet_shutdown.pod
 GENERATE[html/man3/SSL_CTX_set_quiet_shutdown.html]=man3/SSL_CTX_set_quiet_shutdown.pod
 DEPEND[man/man3/SSL_CTX_set_quiet_shutdown.3]=man3/SSL_CTX_set_quiet_shutdown.pod
@@ -3171,6 +3175,7 @@ html/man3/SSL_CTX_set_msg_callback.html \
 html/man3/SSL_CTX_set_num_tickets.html \
 html/man3/SSL_CTX_set_options.html \
 html/man3/SSL_CTX_set_psk_client_callback.html \
+html/man3/SSL_CTX_set_quic_method.html \
 html/man3/SSL_CTX_set_quiet_shutdown.html \
 html/man3/SSL_CTX_set_read_ahead.html \
 html/man3/SSL_CTX_set_record_padding_callback.html \
@@ -3742,6 +3747,7 @@ man/man3/SSL_CTX_set_msg_callback.3 \
 man/man3/SSL_CTX_set_num_tickets.3 \
 man/man3/SSL_CTX_set_options.3 \
 man/man3/SSL_CTX_set_psk_client_callback.3 \
+man/man3/SSL_CTX_set_quic_method.3 \
 man/man3/SSL_CTX_set_quiet_shutdown.3 \
 man/man3/SSL_CTX_set_read_ahead.3 \
 man/man3/SSL_CTX_set_record_padding_callback.3 \

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -388,6 +388,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
     },
 #else
     INVALID_EXTENSION,
+    INVALID_EXTENSION,
 #endif
     {
         /* Must be immediately before pre_shared_key */

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1900,7 +1900,7 @@ EXT_RETURN tls_construct_stoc_early_data(SSL *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_QUIC
         /* QUIC server must always send 0xFFFFFFFF, per draft-ietf-quic-tls-27 S4.5 */
-        if (s->quic_method != NULL)
+        if (SSL_IS_QUIC(s))
             max_early_data = 0xFFFFFFFF;
 #endif
 


### PR DESCRIPTION
Fixes #2 and #5

Updates `Configure` script to disable QUIC with `no-bulk` and `no-ec`
Updates build.info doc docs
Fixes an issue with extension defintions and `no-quic`

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
