### PR TITLE
QUIC: Check and fix FIPS checksums

### DIFF
--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -57,3 +57,29 @@ jobs:
         with:
           name: fips_checksum
           path: artifact/
+  verify-checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install unifdef
+        run: |
+            sudo apt-get update
+            sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
+      - uses: actions/checkout@v2
+      - name: create build dirs
+        run: |
+          mkdir ./build
+      - name: config
+        run: ../config enable-fips && perl configdata.pm --dump
+        working-directory: ./build
+      - name: make build_generated
+        run: make -s build_generated
+        working-directory: ./build
+      - name: make fips-checksums
+        run: make fips-checksums
+        working-directory: ./build
+      - name: make fips-checksums
+        run: make fips-checksums
+        working-directory: ./build
+      - name: make diff-fips-checksums
+        run: make diff-fips-checksums
+        working-directory: ./build

--- a/apps/info.c
+++ b/apps/info.c
@@ -10,6 +10,7 @@
 #include <openssl/crypto.h>
 #include "apps.h"
 #include "progs.h"
+#include <openssl/quic.h>
 
 typedef enum OPTION_choice {
     OPT_COMMON,

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -14,6 +14,7 @@
 #include "internal/cryptlib.h"
 #include "e_os.h"
 #include "buildinf.h"
+#include <openssl/quic.h>
 
 #if defined(__arm__) || defined(__arm) || defined(__aarch64__)
 # include "arm_arch.h"

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -174,10 +174,6 @@ const char *OPENSSL_info(int type);
 # define OPENSSL_INFO_SEED_SOURCE               1007
 # define OPENSSL_INFO_CPU_SETTINGS              1008
 
-# ifndef OPENSSL_NO_QUIC
-#  define OPENSSL_INFO_QUIC                     2000
-# endif
-
 int OPENSSL_issetugid(void);
 
 struct crypto_ex_data_st {

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1739,10 +1739,6 @@ int EVP_PKEY_CTX_set_mac_key(EVP_PKEY_CTX *ctx, const unsigned char *key,
  */
 # define EVP_PKEY_FLAG_SIGCTX_CUSTOM     4
 
-/* Used by Chromium/QUIC */
-# define X25519_PRIVATE_KEY_LEN          32
-# define X25519_PUBLIC_VALUE_LEN         32
-
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 const EVP_PKEY_METHOD *EVP_PKEY_meth_find(int type);
 OSSL_DEPRECATEDIN_3_0 EVP_PKEY_METHOD *EVP_PKEY_meth_new(int id, int flags);

--- a/include/openssl/quic.h
+++ b/include/openssl/quic.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OPENSSL_QUIC_H
+# define OPENSSL_QUIC_H
+# pragma once
+# ifndef OPENSSL_NO_QUIC
+
+/* moved from crypto.h.in to avoid breaking FIPS checksums */
+# define OPENSSL_INFO_QUIC                     2000
+
+# endif /* OPENSSL_NO_QUIC */
+#endif /* OPENSSL_QUIC_H */

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2514,6 +2514,15 @@ const char *OSSL_default_ciphersuites(void);
  * ssl_encryption_level_t represents a specific QUIC encryption level used to
  * transmit handshake messages. BoringSSL has this as an 'enum'.
  */
+#include <openssl/quic.h>
+
+/* Used by Chromium/QUIC - moved from evp.h to avoid breaking FIPS checksums */
+# define X25519_PRIVATE_KEY_LEN          32
+# define X25519_PUBLIC_VALUE_LEN         32
+
+/* moved from types.h to avoid breaking FIPS checksums */
+typedef struct ssl_quic_method_st SSL_QUIC_METHOD;
+
 typedef enum ssl_encryption_level_t {
     ssl_encryption_initial = 0,
     ssl_encryption_early_data,

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -229,8 +229,6 @@ typedef struct ossl_decoder_ctx_st OSSL_DECODER_CTX;
 
 typedef struct ossl_self_test_st OSSL_SELF_TEST;
 
-typedef struct ssl_quic_method_st SSL_QUIC_METHOD;
-
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
     defined(INTMAX_MAX) && defined(UINTMAX_MAX)
 typedef intmax_t ossl_intmax_t;


### PR DESCRIPTION
This reverts some changes to files that are considered to be within the FIPS module boundary, and subsequently would require separate certification of the FIPS provider. With this PR, those changes have been moved to other files outside of the FIPS provider.
This PR also introduces a new CI build, to make sure that changes to FIPS boundary code is avoided.
This means that a vanilla OpenSSL FIPS provider can be used.
