### PR TITLE
Some nits from reviewing the 3.0.0 patchset

### DIFF
--- a/doc/man3/SSL_CTX_set_quic_method.pod
+++ b/doc/man3/SSL_CTX_set_quic_method.pod
@@ -139,8 +139,8 @@ generating their own errors.
 
 See L<https://tools.ietf.org/html/RFC9001#section-4.1> for more details.
 
-To avoid DoS attacks, the QUIC implementation must limit the amount of data
-being queued up. The implementation can call
+To avoid amplifying DoS attacks, the QUIC implementation must limit the amount
+of data being queued up. The implementation can call
 SSL_quic_max_handshake_flight_len() to get the maximum buffer length at each
 encryption level.
 

--- a/doc/man3/SSL_CTX_set_quic_method.pod
+++ b/doc/man3/SSL_CTX_set_quic_method.pod
@@ -82,10 +82,8 @@ SSL_quic_write_level() returns the current write encryption level.
 
 SSL_provide_quic_data() is used to provide data from QUIC CRYPTO frames to the
 state machine, at a particular encryption level B<level>. It is an error to
-call this function outside of the handshake or with an encryption level other
-than the current read level. The application must buffer and consolidate any
-frames with less than four bytes of content.  It returns one on success and
-zero on error.
+call this function with an encryption level less than the current read level.
+It returns one on success and zero on error.
 
 SSL_process_quic_post_handshake() processes any data that QUIC has provided
 after the handshake has completed. This includes NewSessionTicket messages

--- a/doc/man3/SSL_CTX_set_quic_method.pod
+++ b/doc/man3/SSL_CTX_set_quic_method.pod
@@ -209,9 +209,6 @@ only available in the client to server direction. The other secret will be
 NULL. The server acknowledges such data at B<ssl_encryption_application>,
 which will be configured in the same SSL_do_handshake() call.
 
-This function should use SSL_get_current_cipher() to determine the TLS
-cipher suite.
-
 add_handshake_data() adds handshake data to the current flight at the given
 encryption level. It returns one on success and zero on error.
 

--- a/doc/man3/SSL_CTX_set_quic_method.pod
+++ b/doc/man3/SSL_CTX_set_quic_method.pod
@@ -103,7 +103,7 @@ the client will send both extensions.
 SSL_get_quic_transport_version() returns the value set by
 SSL_set_quic_transport_version().
 
-SSL_get_peer_quic_transport_version() returns the version the that was 
+SSL_get_peer_quic_transport_version() returns the version the that was
 negotiated.
 
 SSL_set_quic_early_data_enabled() enables QUIC early data if a nonzero

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1934,7 +1934,7 @@ int tls_parse_stoc_early_data(SSL *s, PACKET *pkt, unsigned int context,
          * QUIC server must send 0xFFFFFFFF or it's a PROTOCOL_VIOLATION
          * per RFC9001 S4.6.1
          */
-        if (s->quic_method != NULL && max_early_data != 0xFFFFFFFF) {
+        if (SSL_IS_QUIC(s) && max_early_data != 0xFFFFFFFF) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_INVALID_MAX_EARLY_DATA);
             return 0;
         }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -906,7 +906,7 @@ int ossl_statem_client_construct_message(SSL *s, WPACKET *pkt,
     case TLS_ST_CW_END_OF_EARLY_DATA:
 #ifndef OPENSSL_NO_QUIC
         /* QUIC does not send EndOfEarlyData, RFC9001 S8.3 */
-        if (s->quic_method != NULL) {
+        if (SSL_IS_QUIC(s)) {
             *confunc = NULL;
             *mt = SSL3_MT_DUMMY;
             break;


### PR DESCRIPTION
There was what seems to be stale content in the man page, and we can use the `SSL_IS_QUIC()` macro in a couple more places.