### PR TITLE
QUIC: Update SSL_clear() to clear quic data (3.0)

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -625,6 +625,38 @@ int SSL_clear(SSL *s)
     s->shared_sigalgs = NULL;
     s->shared_sigalgslen = 0;
 
+#if !defined(OPENSSL_NO_QUIC)
+    OPENSSL_free(s->ext.peer_quic_transport_params_draft);
+    s->ext.peer_quic_transport_params_draft = NULL;
+    s->ext.peer_quic_transport_params_draft_len = 0;
+    OPENSSL_free(s->ext.peer_quic_transport_params);
+    s->ext.peer_quic_transport_params = NULL;
+    s->ext.peer_quic_transport_params_len = 0;
+    s->quic_read_level = ssl_encryption_initial;
+    s->quic_write_level = ssl_encryption_initial;
+    s->quic_latest_level_received = ssl_encryption_initial;
+    while (s->quic_input_data_head != NULL) {
+        QUIC_DATA *qd;
+
+        qd = s->quic_input_data_head;
+        s->quic_input_data_head = qd->next;
+        OPENSSL_free(qd);
+    }
+    s->quic_input_data_tail = NULL;
+    BUF_MEM_free(s->quic_buf);
+    s->quic_buf = NULL;
+    s->quic_next_record_start = 0;
+    memset(s->client_hand_traffic_secret, 0, EVP_MAX_MD_SIZE);
+    memset(s->server_hand_traffic_secret, 0, EVP_MAX_MD_SIZE);
+    memset(s->client_early_traffic_secret, 0, EVP_MAX_MD_SIZE);
+    /*
+     * CONFIG - DON'T CLEAR
+     * s->ext.quic_transport_params
+     * s->ext.quic_transport_params_len
+     * s->quic_transport_version
+     * s->quic_method = NULL;
+     */
+#endif
     /*
      * Check to see if we were changed into a different method, if so, revert
      * back.

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -1030,11 +1030,6 @@ int create_ssl_connection(SSL *serverssl, SSL *clientssl, int want)
     if (!create_bare_ssl_connection(serverssl, clientssl, want, 1))
         return 0;
 
-#ifndef OPENSSL_NO_QUIC
-    /* QUIC does not support SSL_read_ex */
-    if (SSL_is_quic(clientssl))
-        return 1;
-#endif
     /*
      * We attempt to read some data on the client side which we expect to fail.
      * This will ensure we have received the NewSessionTicket in TLSv1.3 where

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9510,6 +9510,7 @@ static int test_quic_api_version(int clnt, int srvr)
     static const char *client_str = "CLIENT";
     const uint8_t *peer_str;
     size_t peer_str_len;
+    int err;
 
     TEST_info("original clnt=0x%X, srvr=0x%X\n", clnt, srvr);
 
@@ -9532,8 +9533,10 @@ static int test_quic_api_version(int clnt, int srvr)
             || !TEST_true(SSL_set_app_data(clientssl, serverssl))
             || !TEST_true(test_quic_api_set_versions(clientssl, clnt))
             || !TEST_true(test_quic_api_set_versions(serverssl, srvr))
-            || !TEST_true(create_ssl_connection(serverssl, clientssl,
-                                                SSL_ERROR_NONE))
+            || !TEST_int_eq(err = SSL_accept(serverssl), -1)
+            || !TEST_int_eq(SSL_get_error(serverssl, err), SSL_ERROR_WANT_READ)
+            || !TEST_true(create_bare_ssl_connection(serverssl, clientssl,
+                                              SSL_ERROR_NONE, 0))
             || !TEST_true(SSL_version(serverssl) == TLS1_3_VERSION)
             || !TEST_true(SSL_version(clientssl) == TLS1_3_VERSION)
             || !(TEST_int_eq(SSL_quic_read_level(clientssl), ssl_encryption_application))
@@ -9660,6 +9663,7 @@ static int quic_setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx,
 {
     static const char *server_str = "SERVER";
     static const char *client_str = "CLIENT";
+    int err;
 
     if (*sctx == NULL
             && (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
@@ -9737,8 +9741,10 @@ static int quic_setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx,
     if (sess == NULL)
         return 1;
 
-    if (!TEST_true(create_ssl_connection(*serverssl, *clientssl,
-                                         SSL_ERROR_NONE)))
+    if (!TEST_int_eq(err = SSL_accept(*serverssl), -1)
+            || !TEST_int_eq(SSL_get_error(*serverssl, err), SSL_ERROR_WANT_READ)
+            || !TEST_true(create_bare_ssl_connection(*serverssl, *clientssl,
+                                                     SSL_ERROR_NONE, 0)))
         return 0;
 
     /* Deal with two NewSessionTickets */
@@ -9777,12 +9783,15 @@ static int test_quic_early_data(int tst)
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
     SSL_SESSION *sess = NULL;
+    int err;
 
     if (!TEST_true(quic_setupearly_data_test(&cctx, &sctx, &clientssl,
                                              &serverssl, &sess, tst)))
         goto end;
 
-    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE))
+    if (!TEST_int_eq(err = SSL_accept(serverssl), -1)
+            || !TEST_int_eq(SSL_get_error(serverssl, err), SSL_ERROR_WANT_READ)
+            || !TEST_true(create_bare_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE, 0))
             || !TEST_true(SSL_get_early_data_status(serverssl)))
         goto end;
 


### PR DESCRIPTION
Fixes #55
Had to fixup tests because SSL_accept() eventually calls SSL_clear() and
it was removing the inital ClientHello sent via SSL_provide_quic_data()
from the server SSL.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
