### PR TITLE
Fix invalid malloc failures in `PEM_write_bio_PKCS8PrivateKey*()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,8 +30,8 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 3.0.0 and 3.0.0+quic [xx XXX xxxx]
 
- * Fixed PEM_write_bio_PKCS8PrivateKey() to make it possible to use empty
-   passphrase strings.
+ * Fixed PEM_write_bio_PKCS8PrivateKey() and PEM_write_bio_PKCS8PrivateKey_nid()
+   to make it possible to use empty passphrase strings.
 
    *Darshan Sen*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,13 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
+### Changes between 3.0.0 and 3.0.0+quic [xx XXX xxxx]
+
+ * Fixed PEM_write_bio_PKCS8PrivateKey() to make it possible to use empty
+   passphrase strings.
+
+   *Darshan Sen*
+
 ### Changes between 3.0.0 and 3.0.0+quic [7 Sun 2021]
 
  * Add QUIC API support from BoringSSL.

--- a/crypto/passphrase.c
+++ b/crypto/passphrase.c
@@ -41,7 +41,8 @@ int ossl_pw_set_passphrase(struct ossl_passphrase_data_st *data,
     ossl_pw_clear_passphrase_data(data);
     data->type = is_expl_passphrase;
     data->_.expl_passphrase.passphrase_copy =
-        OPENSSL_memdup(passphrase, passphrase_len);
+        passphrase_len != 0 ? OPENSSL_memdup(passphrase, passphrase_len)
+                            : OPENSSL_malloc(1);
     if (data->_.expl_passphrase.passphrase_copy == NULL) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -136,7 +136,7 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
         if (enc || (nid != -1)) {
             if (kstr == NULL) {
                 klen = cb(buf, PEM_BUFSIZE, 1, u);
-                if (klen <= 0) {
+                if (klen < 0) {
                     ERR_raise(ERR_LIB_PEM, PEM_R_READ_KEY);
                     goto legacy_end;
                 }

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -114,7 +114,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
 
             if (len >= 0)
                 result[len] = '\0';
-            if (len <= 0)
+            if (len < 0)
                 return len;
             if (UI_set_result_ex(ui, uis, result, len) >= 0)
                 return 1;

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -165,6 +165,20 @@ static int test_print_key_using_pem(const char *alg, const EVP_PKEY *pk)
                                                      EVP_aes_256_cbc(),
                                                      NULL, 0, pass_cb_error,
                                                      NULL))
+#ifndef OPENSSL_NO_DES
+        || !TEST_true(PEM_write_bio_PKCS8PrivateKey_nid(
+            bio_out, pk, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
+            (const char *)~0, 0, NULL, NULL))
+        || !TEST_true(PEM_write_bio_PKCS8PrivateKey_nid(
+            bio_out, pk, NID_pbe_WithSHA1And3_Key_TripleDES_CBC, NULL, 0,
+            NULL, ""))
+        || !TEST_true(PEM_write_bio_PKCS8PrivateKey_nid(
+            bio_out, pk, NID_pbe_WithSHA1And3_Key_TripleDES_CBC, NULL, 0,
+            pass_cb, NULL))
+        || !TEST_false(PEM_write_bio_PKCS8PrivateKey_nid(
+            bio_out, pk, NID_pbe_WithSHA1And3_Key_TripleDES_CBC, NULL, 0,
+            pass_cb_error, NULL))
+#endif
         /* Private key in text form */
         || !TEST_int_gt(EVP_PKEY_print_private(membio, pk, 0, NULL), 0)
         || !TEST_true(compare_with_file(alg, PRIV_TEXT, membio))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This cherry-picks my fix from https://github.com/openssl/openssl/pull/17507, so that I can make use of it in Node.js where we use this fork instead of the main openssl repo for QUIC support.

cc @tmshort 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
